### PR TITLE
Set ssh_pty to true to avoid tty error during packer build

### DIFF
--- a/centos.json
+++ b/centos.json
@@ -7,6 +7,7 @@
   },
   "builders": [{
     "type": "amazon-ebs",
+    "ssh_pty": true,
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "ssh_keypair_name": "{{user `aws_keypair_name`}}",


### PR DESCRIPTION
Using a public Centos source_ami, I was getting an error like this when doing the packer build:
*"sudo: sorry, you must have a tty to run sudo"*
I'm not sure if the same issue arises when using the private AMI used in this repo (ami-c10044a4).

This same issue is referenced [here](https://github.com/mitchellh/packer/issues/1804) and [here](https://github.com/mitchellh/packer/issues/2420), with the stated workaround being to set this value in the packer config:
`"ssh_pty": true`